### PR TITLE
feat: implement nick-fields/retry to address failures in gh cli commands

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,48 +44,53 @@ runs:
       echo "::endgroup::"
 
   - name: Execute Script to Close Redundant PRs and Delete Branches
-    shell: bash
+    uses: nick-fields/retry@v3.0.0
     env:
       GITHUB_PR_NUMBER: ${{ inputs.pr_number }}
       GH_TOKEN: ${{ inputs.gh_token }}
-    run: |
-      parse_pr_headRefName() {
-          local headRefName=$1
-          local app_name=$(echo $headRefName | cut -d'/' -f1)
-          local temp=$(echo $headRefName | cut -d'/' -f2-)
-          local environment=$(echo $temp | cut -d'-' -f2)
-          local tag=$(echo $headRefName | rev | cut -d'-' -f1 | rev)
-          echo $app_name $environment $tag
-      }
+    with:
+      shell: bash
+      retry_on: error
+      timeout_minutes: 2
+      max_attempts: 3
+      command: |
+        parse_pr_headRefName() {
+            local headRefName=$1
+            local app_name=$(echo $headRefName | cut -d'/' -f1)
+            local temp=$(echo $headRefName | cut -d'/' -f2-)
+            local environment=$(echo $temp | cut -d'-' -f2)
+            local tag=$(echo $headRefName | rev | cut -d'-' -f1 | rev)
+            echo $app_name $environment $tag
+        }
 
-      close_pr_and_delete_branch() {
-          local pr_number=$1
-          local branch_name=$2
+        close_pr_and_delete_branch() {
+            local pr_number=$1
+            local branch_name=$2
 
-          gh pr close $pr_number
+            gh pr close $pr_number
 
-          gh api -X DELETE repos/:owner/:repo/git/refs/heads/$branch_name
-      }
+            gh api -X DELETE repos/:owner/:repo/git/refs/heads/$branch_name
+        }
 
-      main() {
-          trigger_pr_number=$1
-          trigger_pr=$(gh pr view $trigger_pr_number --json headRefName)
-          trigger_pr_branch=$(echo $trigger_pr | jq -r '.headRefName')
-          read trigger_pr_app_name trigger_pr_environment trigger_pr_tag <<< $(parse_pr_headRefName "$trigger_pr_branch")
+        main() {
+            trigger_pr_number=$1
+            trigger_pr=$(gh pr view $trigger_pr_number --json headRefName)
+            trigger_pr_branch=$(echo $trigger_pr | jq -r '.headRefName')
+            read trigger_pr_app_name trigger_pr_environment trigger_pr_tag <<< $(parse_pr_headRefName "$trigger_pr_branch")
 
-          open_prs=$(gh pr list --state open --json number,headRefName)
+            open_prs=$(gh pr list --state open --json number,headRefName)
 
-          echo "$open_prs" | jq -c '.[]' | while read pr; do
-              open_pr_number=$(echo $pr | jq -r '.number')
-              open_pr_branch=$(echo $pr | jq -r '.headRefName')
-              read open_pr_app_name open_pr_environment open_pr_tag <<< $(parse_pr_headRefName "$open_pr_branch")
+            echo "$open_prs" | jq -c '.[]' | while read pr; do
+                open_pr_number=$(echo $pr | jq -r '.number')
+                open_pr_branch=$(echo $pr | jq -r '.headRefName')
+                read open_pr_app_name open_pr_environment open_pr_tag <<< $(parse_pr_headRefName "$open_pr_branch")
 
-              if [ "$trigger_pr_app_name" == "$open_pr_app_name" ] && [ "$trigger_pr_environment" == "$open_pr_environment" ] && [ "$trigger_pr_tag" != "$open_pr_tag" ] && [ $trigger_pr_number -gt $open_pr_number ]; then
-                  close_pr_and_delete_branch $open_pr_number $open_pr_branch
-              fi
-          done
-      }
+                if [ "$trigger_pr_app_name" == "$open_pr_app_name" ] && [ "$trigger_pr_environment" == "$open_pr_environment" ] && [ "$trigger_pr_tag" != "$open_pr_tag" ] && [ $trigger_pr_number -gt $open_pr_number ]; then
+                    close_pr_and_delete_branch $open_pr_number $open_pr_branch
+                fi
+            done
+        }
 
-      echo "::group::cleaning up redundant PRs and branches"
-      main $GITHUB_PR_NUMBER
-      echo "::endgroup::"
+        echo "::group::cleaning up redundant PRs and branches"
+        main $GITHUB_PR_NUMBER
+        echo "::endgroup::"


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Integrated `nick-fields/retry@v3.0.0` to add retry logic to the GitHub CLI commands used in the script for closing redundant PRs and deleting branches.
- Configured the retry action to attempt a maximum of 3 retries with a 2-minute timeout for each attempt, improving the robustness of the automation against transient failures.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Integrate Retry Mechanism for GH CLI Commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
action.yml

<li>Integrated <code>nick-fields/retry</code> action for retrying failed commands.<br> <li> Added configuration for retrying with a maximum of 3 attempts and a <br>timeout of 2 minutes.<br> <li> Encapsulated the existing bash script within the retry action's <br>command parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/github-actions-cleanup-redundant-cd-prs/pull/14/files#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6">+39/-34</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

